### PR TITLE
Add Forgot Password page + unit tests for Auth pages

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -6,6 +6,7 @@ import Policy from "./pages/Policy";
 import Pagenotfound from "./pages/Pagenotfound";
 import Register from "./pages/Auth/Register";
 import Login from "./pages/Auth/Login";
+import ForgotPassword from "./pages/Auth/ForgotPassword"; 
 import Dashboard from "./pages/user/Dashboard";
 import PrivateRoute from "./components/Routes/Private";
 import AdminRoute from "./components/Routes/AdminRoute";
@@ -49,6 +50,7 @@ function App() {
         </Route>
         <Route path="/register" element={<Register />} />
         <Route path="/login" element={<Login />} />
+        <Route path="/forgot-password" element={<ForgotPassword />} />
         <Route path="/about" element={<About />} />
         <Route path="/contact" element={<Contact />} />
         <Route path="/policy" element={<Policy />} />

--- a/client/src/pages/Auth/ForgotPassword.js
+++ b/client/src/pages/Auth/ForgotPassword.js
@@ -1,0 +1,93 @@
+import React, { useState } from "react";
+import Layout from "./../../components/Layout";
+import axios from "axios";
+import { useNavigate } from "react-router-dom";
+import toast from "react-hot-toast";
+import "../../styles/AuthStyles.css";
+
+const ForgotPassword = () => {
+  const [email, setEmail] = useState("");
+  const [answer, setAnswer] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+ 
+  const navigate = useNavigate();
+
+  // form function
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      const res = await axios.post("/api/v1/auth/forgot-password", {
+        email,
+        answer,
+        newPassword,
+      });
+
+      if (res && res.data.success) {
+        toast.success(res.data && res.data.message, {
+            duration: 5000,
+            icon: "🙏",
+            style: {
+              background: "green",
+              color: "white",
+            },
+          });
+
+        navigate("/login");
+      } else {
+        toast.error(res.data.message);
+      }
+    } catch (error) {
+      console.log(error);
+      toast.error("Something went wrong");
+    }
+  };
+  return (
+    <Layout title="ForgotPassword - Ecommerce App">
+      <div className="form-container " style={{ minHeight: "90vh" }}>
+        <form onSubmit={handleSubmit}>
+          <h4 className="title">FORGOT PASSWORD FORM</h4>
+
+          <div className="mb-3">
+            <input
+              type="email"
+              autoFocus
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="form-control"
+              id="exampleInputEmail"
+              placeholder="Enter Your Email "
+              required
+            />
+          </div>
+          <div className="mb-3">
+            <input
+              type="answer"
+              value={answer}
+              onChange={(e) => setAnswer(e.target.value)}
+              className="form-control"
+              id="exampleInputAnswer"
+              placeholder="Enter Your Answer"
+              required
+            />
+          </div>
+          <div className="mb-3">
+            <input
+              type="newPassword"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              className="form-control"
+              id="exampleInputNewPassword"
+              placeholder="Enter Your New Password"
+              required
+            />
+          </div>
+          <button type="submit" className="btn btn-primary">
+            Reset Password
+          </button>
+        </form>
+      </div>
+    </Layout>
+  );
+};
+
+export default ForgotPassword;

--- a/client/src/pages/Auth/ForgotPassword.js
+++ b/client/src/pages/Auth/ForgotPassword.js
@@ -82,7 +82,7 @@ const ForgotPassword = () => {
             />
           </div>
           <button type="submit" className="btn btn-primary">
-            Reset Password
+            RESET PASSWORD
           </button>
         </form>
       </div>

--- a/client/src/pages/Auth/ForgotPassword.test.js
+++ b/client/src/pages/Auth/ForgotPassword.test.js
@@ -1,0 +1,245 @@
+import React from "react";
+import { render, fireEvent, waitFor } from "@testing-library/react";
+import axios from "axios";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import "@testing-library/jest-dom/extend-expect";
+import toast from "react-hot-toast";
+import ForgotPassword from "./ForgotPassword";
+
+// Mocking axios.post
+jest.mock("axios");
+jest.mock("react-hot-toast");
+
+jest.mock("../../context/auth", () => ({
+  useAuth: jest.fn(() => [null, jest.fn()]), // Mock useAuth hook to return null state and a mock function for setAuth
+}));
+
+jest.mock("../../context/cart", () => ({
+  useCart: jest.fn(() => [null, jest.fn()]), // Mock useCart hook to return null state and a mock function
+}));
+
+jest.mock("../../context/search", () => ({
+  useSearch: jest.fn(() => [{ keyword: "" }, jest.fn()]), // Mock useSearch hook to return null state and a mock function
+}));
+
+jest.mock("../../hooks/useCategory", () => jest.fn(() => []));
+
+const mockedUsedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+   ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockedUsedNavigate,
+}));
+
+Object.defineProperty(window, "localStorage", {
+  value: {
+    setItem: jest.fn(),
+    getItem: jest.fn(),
+    removeItem: jest.fn(),
+  },
+  writable: true,
+});
+
+window.matchMedia =
+  window.matchMedia ||
+  function () {
+    return {
+      matches: false,
+      addListener: function () {},
+      removeListener: function () {},
+    };
+  };
+
+describe("ForgotPassword Component", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders forgot password form", () => {
+    const { getByText, getByPlaceholderText } = render(
+      <MemoryRouter initialEntries={["/forgot-password"]}>
+        <Routes>
+          <Route path="/forgot-password" element={<ForgotPassword />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(getByText("FORGOT PASSWORD FORM")).toBeInTheDocument();
+    expect(getByPlaceholderText("Enter Your Email")).toBeInTheDocument();
+    expect(getByPlaceholderText("Enter Your Answer")).toBeInTheDocument();
+    expect(getByPlaceholderText("Enter Your New Password")).toBeInTheDocument();
+  });
+
+  it("inputs should be initially empty", () => {
+    const { getByText, getByPlaceholderText } = render(
+      <MemoryRouter initialEntries={["/forgot-password"]}>
+        <Routes>
+          <Route path="/forgot-password" element={<ForgotPassword />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(getByText("FORGOT PASSWORD FORM")).toBeInTheDocument();
+    expect(getByPlaceholderText("Enter Your Email").value).toBe("");
+    expect(getByPlaceholderText("Enter Your Answer").value).toBe("");
+    expect(getByPlaceholderText("Enter Your New Password").value).toBe("");
+  });
+
+  it("should allow typing email, answer and new password", () => {
+    const { getByText, getByPlaceholderText } = render(
+      <MemoryRouter initialEntries={["/forgot-password"]}>
+        <Routes>
+          <Route path="/forgot-password" element={<ForgotPassword />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    fireEvent.change(getByPlaceholderText("Enter Your Email"), {
+      target: { value: "test@example.com" },
+    });
+    fireEvent.change(getByPlaceholderText("Enter Your Answer"), {
+      target: { value: "Football" },
+    });
+    fireEvent.change(getByPlaceholderText("Enter Your New Password"), {
+      target: { value: "password123" },
+    });
+    expect(getByPlaceholderText("Enter Your Email").value).toBe(
+      "test@example.com"
+    );
+    expect(getByPlaceholderText("Enter Your Answer").value).toBe(
+      "Football"
+    );
+    expect(getByPlaceholderText("Enter Your New Password").value).toBe(
+      "password123"
+    );
+  });
+
+  it("should reset the password successfully", async () => {
+    axios.post.mockResolvedValueOnce({
+      data: {
+        success: true,
+        user: { id: 1, name: "John Doe", email: "test@example.com" },
+        token: "mockToken",
+      },
+    });
+
+    const { getByPlaceholderText, getByText } = render(
+      <MemoryRouter initialEntries={["/forgot-password"]}>
+        <Routes>
+          <Route path="/forgot-password" element={<ForgotPassword />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.change(getByPlaceholderText("Enter Your Email"), {
+      target: { value: "test@example.com" },
+    });
+    fireEvent.change(getByPlaceholderText("Enter Your Answer"), {
+      target: { value: "Football" },
+    });
+    fireEvent.change(getByPlaceholderText("Enter Your New Password"), {
+      target: { value: "password123" },
+    });
+    fireEvent.click(getByText("RESET PASSWORD"));
+
+    await waitFor(() => expect(axios.post).toHaveBeenCalled());
+    expect(toast.success).toHaveBeenCalledWith(undefined, {
+      duration: 5000,
+      icon: "🙏",
+      style: {
+        background: "green",
+        color: "white",
+      },
+    });
+    expect(mockedUsedNavigate).toHaveBeenCalledWith("/login");
+  });
+
+  it("should display error message on failed password reset", async () => {
+    axios.post.mockRejectedValueOnce({ message: "Test for Invalid credentials" });
+
+    const { getByPlaceholderText, getByText } = render(
+      <MemoryRouter initialEntries={["/forgot-password"]}>
+        <Routes>
+          <Route path="/forgot-password" element={<ForgotPassword />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.change(getByPlaceholderText("Enter Your Email"), {
+      target: { value: "test@example.com" },
+    });
+    fireEvent.change(getByPlaceholderText("Enter Your Answer"), {
+      target: { value: "Football" },
+    });
+    fireEvent.change(getByPlaceholderText("Enter Your New Password"), {
+      target: { value: "password123" },
+    });
+    fireEvent.click(getByText("RESET PASSWORD"));
+
+    await waitFor(() => expect(axios.post).toHaveBeenCalled());
+    expect(toast.error).toHaveBeenCalledWith("Something went wrong");
+  });
+
+  it("should not call API if input is empty", async () => {
+    const { getByText } = render(
+      <MemoryRouter initialEntries={["/forgot-password"]}>
+        <Routes>
+          <Route path="/forgot-password" element={<ForgotPassword />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(getByText("RESET PASSWORD"));
+
+    await waitFor(() => expect(axios.post).not.toHaveBeenCalled());
+  });
+
+  it("should not call API if email is invalid format", async () => {
+    const { getByPlaceholderText, getByText } = render(
+      <MemoryRouter initialEntries={["/forgot-password"]}>
+        <Routes>
+          <Route path="/forgot-password" element={<ForgotPassword />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.change(getByPlaceholderText("Enter Your Email"), {
+      target: { value: "invalid-email" }, // no @ sign
+    });
+    fireEvent.change(getByPlaceholderText("Enter Your Answer"), {
+      target: { value: "Football" },
+    });
+    fireEvent.change(getByPlaceholderText("Enter Your New Password"), {
+      target: { value: "password123" },
+    });
+    fireEvent.click(getByText("RESET PASSWORD"));
+    await waitFor(() => expect(axios.post).not.toHaveBeenCalled());
+  });
+
+  it("should show error toast when request fails", async () => {
+    axios.post.mockResolvedValueOnce({ data: { success: false, message: "Login Failed" } });
+
+    const { getByPlaceholderText, getByText } = render(
+      <MemoryRouter initialEntries={["/forgot-password"]}>
+        <Routes>
+          <Route path="/forgot-password" element={<ForgotPassword />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.change(getByPlaceholderText("Enter Your Email"), {
+      target: { value: "test@example.com" },
+    });
+    fireEvent.change(getByPlaceholderText("Enter Your Answer"), {
+      target: { value: "Football" },
+    });
+    fireEvent.change(getByPlaceholderText("Enter Your New Password"), {
+      target: { value: "password123" },
+    });
+    fireEvent.click(getByText("RESET PASSWORD"));
+
+    await waitFor(() => expect(axios.post).toHaveBeenCalled());
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalled();
+    });
+  });
+});

--- a/client/src/pages/Auth/Login.test.js
+++ b/client/src/pages/Auth/Login.test.js
@@ -270,4 +270,30 @@ describe("Login Component", () => {
     await waitFor(() => expect(axios.post).toHaveBeenCalled());
     expect(mockedUsedNavigate).toHaveBeenCalledWith("/");
   });
+
+  it("should show error toast when request fails", async () => {
+    axios.post.mockResolvedValueOnce({ data: { success: false, message: "Login Failed" } });
+
+
+    const { getByPlaceholderText, getByText } = render(
+      <MemoryRouter initialEntries={[{ pathname: "/login" }]}>
+        <Routes>
+          <Route path="/login" element={<Login />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.change(getByPlaceholderText("Enter Your Email"), {
+      target: { value: "test@example.com" },
+    });
+    fireEvent.change(getByPlaceholderText("Enter Your Password"), {
+      target: { value: "password123" },
+    });
+    fireEvent.click(getByText("LOGIN"));
+
+    await waitFor(() => expect(axios.post).toHaveBeenCalled());
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalled();
+    });
+  });
 });

--- a/client/src/pages/Auth/Login.test.js
+++ b/client/src/pages/Auth/Login.test.js
@@ -273,7 +273,6 @@ describe("Login Component", () => {
   it("should show error toast when request fails", async () => {
     axios.post.mockResolvedValueOnce({ data: { success: false, message: "Login Failed" } });
 
-
     const { getByPlaceholderText, getByText } = render(
       <MemoryRouter initialEntries={[{ pathname: "/login" }]}>
         <Routes>

--- a/client/src/pages/Auth/Login.test.js
+++ b/client/src/pages/Auth/Login.test.js
@@ -1,11 +1,10 @@
 import React from "react";
 import { render, fireEvent, waitFor } from "@testing-library/react";
 import axios from "axios";
-import { MemoryRouter, Routes, Route, useNavigate } from "react-router-dom";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
 import "@testing-library/jest-dom/extend-expect";
 import toast from "react-hot-toast";
 import Login from "./Login";
-import ForgotPassword from "./ForgotPassword";
 
 // Mocking axios.post
 jest.mock("axios");

--- a/client/src/pages/Auth/Register.test.js
+++ b/client/src/pages/Auth/Register.test.js
@@ -49,6 +49,74 @@ describe("Register Component", () => {
     jest.clearAllMocks();
   });
 
+  it ("renders Register Form", () => {
+    const { getByText, getByPlaceholderText } = render(
+      <MemoryRouter initialEntries={["/register"]}>
+        <Routes>
+          <Route path="/register" element={<Register />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(getByText("REGISTER FORM")).toBeInTheDocument();
+    expect(getByPlaceholderText("Enter Your Name")).toBeInTheDocument();
+    expect(getByPlaceholderText("Enter Your Email")).toBeInTheDocument();
+    expect(getByPlaceholderText("Enter Your Password")).toBeInTheDocument();
+    expect(getByPlaceholderText("Enter Your Phone")).toBeInTheDocument();
+    expect(getByPlaceholderText("Enter Your Address")).toBeInTheDocument();
+    expect(getByPlaceholderText("Enter Your DOB")).toBeInTheDocument();
+    expect(getByPlaceholderText("What is Your Favorite sports")).toBeInTheDocument();
+  });
+
+  it ("inputs should be initially empty" , () => {  
+    const { getByText, getByPlaceholderText } = render(
+      <MemoryRouter initialEntries={["/register"]}>
+        <Routes>
+          <Route path="/register" element={<Register />} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(getByText("REGISTER FORM")).toBeInTheDocument();
+    expect(getByPlaceholderText("Enter Your Name").value).toBe("");
+    expect(getByPlaceholderText("Enter Your Email").value).toBe("");
+    expect(getByPlaceholderText("Enter Your Password").value).toBe("");
+    expect(getByPlaceholderText("Enter Your Phone").value).toBe("");
+    expect(getByPlaceholderText("Enter Your Address").value).toBe("");
+    expect(getByPlaceholderText("Enter Your DOB").value).toBe("");
+    expect(getByPlaceholderText("What is Your Favorite sports").value).toBe("");
+  });
+
+  it ("should allow typing in the inputs", () => {
+    const { getByText, getByPlaceholderText } = render(
+      <MemoryRouter initialEntries={["/register"]}>
+        <Routes>
+          <Route path="/register" element={<Register />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.change(getByPlaceholderText("Enter Your Name"), {
+      target: { value: "John Doe" },
+    });
+    fireEvent.change(getByPlaceholderText("Enter Your Email"), {
+      target: { value: "test@example.com" },
+    });
+    fireEvent.change(getByPlaceholderText("Enter Your Password"), {
+      target: { value: "password123" },
+    });
+    fireEvent.change(getByPlaceholderText("Enter Your Phone"), {
+      target: { value: "1234567890" },
+    });
+    fireEvent.change(getByPlaceholderText("Enter Your Address"), {
+      target: { value: "123 Street" },
+    });
+    fireEvent.change(getByPlaceholderText("Enter Your DOB"), {
+      target: { value: "2000-01-01" },
+    });
+    fireEvent.change(getByPlaceholderText("What is Your Favorite sports"), {
+      target: { value: "Football" },
+    });
+  }); 
+
   it("should register the user successfully", async () => {
     axios.post.mockResolvedValueOnce({ data: { success: true } });
 
@@ -90,8 +158,41 @@ describe("Register Component", () => {
     );
   });
 
+  it ("should show validation error if fields are empty", async () => {
+    const { getByText, getByPlaceholderText } = render(
+      <MemoryRouter initialEntries={["/register"]}>
+        <Routes>
+          <Route path="/register" element={<Register />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.change(getByPlaceholderText("Enter Your Email"), {
+      target: { value: "test@example.com" },
+    });
+    fireEvent.change(getByPlaceholderText("Enter Your Password"), {
+      target: { value: "password123" },
+    });
+    fireEvent.change(getByPlaceholderText("Enter Your Phone"), {
+      target: { value: "1234567890" },
+    });
+    fireEvent.change(getByPlaceholderText("Enter Your Address"), {
+      target: { value: "123 Street" },
+    });
+    fireEvent.change(getByPlaceholderText("Enter Your DOB"), {
+      target: { value: "2000-01-01" },
+    });
+    fireEvent.change(getByPlaceholderText("What is Your Favorite sports"), {
+      target: { value: "Football" },
+    });
+
+    fireEvent.click(getByText("REGISTER"));
+
+    await waitFor(() => expect(axios.post).not.toHaveBeenCalled());
+  });
+
   it("should display error message on failed registration", async () => {
-    axios.post.mockRejectedValueOnce({ message: "User already exists" });
+    axios.post.mockRejectedValueOnce({ message: "Test for User already exists" });
 
     const { getByText, getByPlaceholderText } = render(
       <MemoryRouter initialEntries={["/register"]}>
@@ -127,5 +228,82 @@ describe("Register Component", () => {
 
     await waitFor(() => expect(axios.post).toHaveBeenCalled());
     expect(toast.error).toHaveBeenCalledWith("Something went wrong");
+  });
+
+  it ("should not accept invalid email", async () => {
+    const { getByText, getByPlaceholderText } = render(
+      <MemoryRouter initialEntries={["/register"]}>
+        <Routes>
+          <Route path="/register" element={<Register />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.change(getByPlaceholderText("Enter Your Name"), {
+      target: { value: "John Doe" },
+    });
+    fireEvent.change(getByPlaceholderText("Enter Your Email"), {
+      target: { value: "invalid-email" },
+    });
+    fireEvent.change(getByPlaceholderText("Enter Your Password"), {
+      target: { value: "password123" },
+    });
+    fireEvent.change(getByPlaceholderText("Enter Your Phone"), {
+      target: { value: "1234567890" },
+    });
+    fireEvent.change(getByPlaceholderText("Enter Your Address"), {
+      target: { value: "123 Street" },
+    });
+    fireEvent.change(getByPlaceholderText("Enter Your DOB"), {
+      target: { value: "2000-01-01" },
+    });
+    fireEvent.change(getByPlaceholderText("What is Your Favorite sports"), {
+      target: { value: "Football" },
+    });
+
+    fireEvent.click(getByText("REGISTER"));
+    await waitFor(() => expect(axios.post).not.toHaveBeenCalled());
+  });
+
+  it("should show error toast when request fails", async () => {
+    axios.post.mockResolvedValueOnce({ data: { success: false, message: "Registration Failed" } });
+
+    const { getByText, getByPlaceholderText } = render(
+      <MemoryRouter initialEntries={["/register"]}>
+        <Routes>
+          <Route path="/register" element={<Register />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.change(getByPlaceholderText("Enter Your Name"), {
+      target: { value: "John Doe" },
+    });
+    fireEvent.change(getByPlaceholderText("Enter Your Email"), {
+      target: { value: "test@example.com" },
+    });
+    fireEvent.change(getByPlaceholderText("Enter Your Password"), {
+      target: { value: "password123" },
+    });
+    fireEvent.change(getByPlaceholderText("Enter Your Phone"), {
+      target: { value: "1234567890" },
+    });
+    fireEvent.change(getByPlaceholderText("Enter Your Address"), {
+      target: { value: "123 Street" },
+    });
+    fireEvent.change(getByPlaceholderText("Enter Your DOB"), {
+      target: { value: "2000-01-01" },
+    });
+    fireEvent.change(getByPlaceholderText("What is Your Favorite sports"), {
+      target: { value: "Football" },
+    });
+
+    fireEvent.click(getByText("REGISTER"));
+
+    await waitFor(() => expect(axios.post).toHaveBeenCalled());
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalled();
+    });
+    
   });
 });

--- a/client/src/pages/Auth/Register.test.js
+++ b/client/src/pages/Auth/Register.test.js
@@ -24,6 +24,14 @@ jest.mock("../../context/search", () => ({
 
 jest.mock("../../hooks/useCategory", () => jest.fn(() => []));
 
+const mockedUsedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+   ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockedUsedNavigate,
+}));
+
+
 // Object.defineProperty(window, "localStorage", {
 //   value: {
 //     setItem: jest.fn(),
@@ -118,8 +126,13 @@ describe("Register Component", () => {
   }); 
 
   it("should register the user successfully", async () => {
-    axios.post.mockResolvedValueOnce({ data: { success: true } });
-
+    axios.post.mockResolvedValueOnce({
+      data: {
+        success: true,
+        user: { id: 1, name: "John Doe", email: "test@example.com" },
+        token: "mockToken",
+      },
+    });
     const { getByText, getByPlaceholderText } = render(
       <MemoryRouter initialEntries={["/register"]}>
         <Routes>
@@ -156,6 +169,7 @@ describe("Register Component", () => {
     expect(toast.success).toHaveBeenCalledWith(
       "Register Successfully, please login"
     );
+    expect(mockedUsedNavigate).toHaveBeenCalledWith("/login");
   });
 
   it ("should show validation error if fields are empty", async () => {


### PR DESCRIPTION
Add Missing Forgot Password page as clicking on forgot password used to bring you to error 404 page.
Add unit tests for ForgotPassword.js, Login.js and Register.js.